### PR TITLE
Security/Feature Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.2.0]
+- Vuln patches
+  - [CVE-2020-13949](https://github.com/xmidt-org/mimisbrunnr/issues/56)
 - making updates to dispatcher [#17](https://github.com/xmidt-org/mimisbrunnr/pull/17)
 - added mutex to prevent data races [#16](https://github.com/xmidt-org/mimisbrunnr/pull/16)
 - added documentation and enhancements [#20](https://github.com/xmidt-org/mimisbrunnr/pull/20)
@@ -16,5 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Initial creation
 - Updated references to the main branch [#6](https://github.com/xmidt-org/mimisbrunnr/pull/6)
 
-[Unreleased]: https://github.com/xmidt-org/mimisbrunnr/compare/v0.1.0..HEAD
+[Unreleased]: https://github.com/xmidt-org/mimisbrunnr/compare/v0.2.0..HEAD
+[v0.2.0]: https://github.com/xmidt-org/mimisbrunnr/compare/0.1.0...v0.2.0
 [v0.1.0]: https://github.com/xmidt-org/mimisbrunnr/compare/0.0.0...v0.1.0


### PR DESCRIPTION
What's included:
- Vuln patches
  - [CVE-2020-13949](https://github.com/xmidt-org/mimisbrunnr/issues/56)
- making updates to dispatcher [#17](https://github.com/xmidt-org/mimisbrunnr/pull/17)
- added mutex to prevent data races [#16](https://github.com/xmidt-org/mimisbrunnr/pull/16)
- added documentation and enhancements [#20](https://github.com/xmidt-org/mimisbrunnr/pull/20)
- Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#27](https://github.com/xmidt-org/mimisbrunnr/pull/27)
- Updated spec file and rpkg version macro to be able to choose when the 'v' is included in the version. [#31](https://github.com/xmidt-org/mimisbrunnr/pull/31)
- Patched failing docker image, remove deprecated use of Maintainer, fixed linter complaints and enabled linting. [#76](https://github.com/xmidt-org/mimisbrunnr/pull/76)
